### PR TITLE
Replace `base.HEX` with `base.NONE`

### DIFF
--- a/dissect/protobuf_dissector/modules/generic/proto_fields.lua
+++ b/dissect/protobuf_dissector/modules/generic/proto_fields.lua
@@ -33,7 +33,7 @@ local proto_pfields = {
     tag      = ProtoField.uint32("protobuf.tag", "Tag", base.DEC, nil, nil, "Field tag value"),
     wiretype = ProtoField.uint8 ("protobuf.wiretype", "Wire Type", base.DEC, wiretype_valstring, 0x07, "Field wire type value"),
     length   = ProtoField.uint32("protobuf.length", "Length", base.DEC, nil, nil, "Field length"),
-    value    = ProtoField.bytes ("protobuf.value", "Value", base.HEX, nil, nil, "Field value bytes"),
+    value    = ProtoField.bytes ("protobuf.value", "Value", base.NONE, nil, nil, "Field value bytes"),
     length_delimiter = ProtoField.uint32("protobuf.length_delimiter_value", "Length Delimiter Value", base.DEC, nil, nil, "Field length-delimited length value"),
 
     -- following are for wiretypes for unknown fields
@@ -41,7 +41,7 @@ local proto_pfields = {
     FIXED64  = ProtoField.uint64("protobuf.fixed64", "Fixed64 Value", base.DEC, nil, nil, "Unknown Fixed64 Field value"),
     VARINT   = ProtoField.uint64("protobuf.varint", "Varint Value", base.DEC, nil, nil, "Unknown Varint Field value"),
     GROUP    = ProtoField.bytes ("protobuf.group", "Group", base.NONE, nil, nil, "Unknown Group Field"),
-    LENGTH_BYTES = ProtoField.bytes("protobuf.length_delimited_bytes", "Length Delimited Bytes", base.HEX, nil, nil, "Unknown Length Delimited Field"),
+    LENGTH_BYTES = ProtoField.bytes("protobuf.length_delimited_bytes", "Length Delimited Bytes", base.NONE, nil, nil, "Unknown Length Delimited Field"),
 }
 
 


### PR DESCRIPTION
Fixes some lua errors on the newer versions of Wireshark