### PR TITLE
Support ASLR on Linux.

### DIFF
--- a/dump/dump.c
+++ b/dump/dump.c
@@ -123,12 +123,17 @@ static void patch_shn(void) {
     unsigned long long start, end = 0;
     FILE *mapfile = fopen("/proc/self/maps", "r");
     assert(mapfile != NULL);
-    char line[256];
-    // TODO: Search through the file for the text segment rather than assuming it's the first line.
-    if (fgets(line, sizeof(line), mapfile)) {
-        sscanf(line,"%llx-%llx", &start, &end);
+    char line[256], flags[4];
+    unsigned found = 0;
+    while (fgets(line, sizeof(line), mapfile)) {
+        sscanf(line,"%llx-%llx %4s", &start, &end, flags);
+        if (strstr(flags, "r-xp")) {
+            found = 1;
+            break;
+        }
     }
     fclose(mapfile);
+    assert(found == 1);
     text_size = end - start;
     text_start = (void*)(uintptr_t)start;
 #endif


### PR DESCRIPTION
The process map on Ubuntu has changed and the text segment has moved.
```
Previously (16.04):
00400000-02bdc000 r-xp 00000000 103:05 3411267                           /usr/share/spotify/spotify
02bdd000-02bdf000 r--p 027dc000 103:05 3411267                           /usr/share/spotify/spotify
02bdf000-02fe8000 rwxp 027de000 103:05 3411267                           /usr/share/spotify/spotify

Now (18.10):
00200000-010ed000 r--p 00000000 103:06 4471655                           /usr/share/spotify/spotify
010ed000-021e1000 r-xp 00eed000 103:06 4471655                           /usr/share/spotify/spotify
021e1000-025f5000 rwxp 01fe1000 103:06 4471655 /usr/share/spotify/spotify
```

I guess they enabled ALSR for everything. Either way, this fix works and was what the code should have done in the first place. There is some more context at https://github.com/librespot-org/spotify-analyze/pull/1.