### PR TITLE
Adjust protocol name to avoid clash with built-in Protobuf dissector

### DIFF
--- a/dissect/protobuf_dissector/modules/generic/proto.lua
+++ b/dissect/protobuf_dissector/modules/generic/proto.lua
@@ -32,7 +32,7 @@ local GenericExperts     = require "generic.experts"
 local GenericProto = {}
 
 
-GenericProto.proto = Proto.new("Protobuf", "Google Protobuf Format")
+GenericProto.proto = Proto.new("Protobuf_", "Google Protobuf Format")
 
 local pfields = GenericProtoFields:getFields()
 


### PR DESCRIPTION
Wireshark (now?) includes a [Protobuf dissector](https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-protobuf.c) but it doesn't seem to support loading .proto files so isn't that useful. Our dissector name clashes with that built-in one and gives an annoying message on startup.

EDIT:
Oh, and I don't take credit for this. Someone else suggested doing this ages ago (maybe @ashthespy ?). I just want what's checked-in to work.