### PR TITLE
Decode spirc frame protobuf

### DIFF
--- a/dissect/dissect.bat
+++ b/dissect/dissect.bat
@@ -8,4 +8,5 @@
     -X lua_script:gaia.lua ^
     -X lua_script1:proto/keyexchange.proto ^
     -X lua_script1:proto/authentication.proto ^
+    -X lua_script1:proto/spirc.proto ^
     -X lua_script1:proto/mercury.proto

--- a/dissect/dissect.sh
+++ b/dissect/dissect.sh
@@ -8,4 +8,5 @@ exec wireshark-gtk $1 \
     -X lua_script:gaia.lua \
     -X lua_script1:proto/keyexchange.proto \
     -X lua_script1:proto/authentication.proto \
+    -X lua_script1:proto/spirc.proto \
     -X lua_script1:proto/mercury.proto

--- a/dissect/proto/spirc.proto
+++ b/dissect/proto/spirc.proto
@@ -1,4 +1,4 @@
-message Frame {
+message SpircFrame {
     optional uint32 version = 0x1;
     optional string ident = 0x2;
     optional string protocol_version = 0x3;

--- a/dissect/spotify.lua
+++ b/dissect/spotify.lua
@@ -34,6 +34,10 @@ function spotify.dissector(buffer, pinfo, tree)
         DissectorTable.get("protobuf"):try("APWelcome", payload, pinfo, tree)
     elseif cmd:uint() == 0xad then
         DissectorTable.get("protobuf"):try("APLoginFailed", payload, pinfo, tree)
+    elseif cmd:uint() == 0x0c then
+        pinfo.cols.info = "Req AudioKey: " .. payload()
+    elseif cmd:uint() == 0x0d then
+        pinfo.cols.info = "Got AudioKey: " .. payload()
     else
         DissectorTable.get("spotify.cmd"):try(cmd:uint(), payload, pinfo, tree)
     end

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -54,19 +54,19 @@ static void my_shn_decrypt(shn_ctx * c, UCHAR * buf, int nbytes) {
     } __attribute__((packed)) header = { 0, 0 };
 
     if (header.cmd == 0) {
-        assert(nbytes == 3);
-        memcpy(&header, buf, 3);
+        if (nbytes == 3)
+            memcpy(&header, buf, 3);
     } else {
-        assert(nbytes == ntohs(header.length));
+        if (nbytes == ntohs(header.length)) {
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            pcap_write_packet_header(dump_fd, &tv, 4 + nbytes);
 
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        pcap_write_packet_header(dump_fd, &tv, 4 + nbytes);
-
-        uint8_t direction = DIRECTION_RECV;
-        write(dump_fd, &direction, 1);
-        write(dump_fd, &header, 3);
-        write(dump_fd, buf, nbytes);
+            uint8_t direction = DIRECTION_RECV;
+            write(dump_fd, &direction, 1);
+            write(dump_fd, &header, 3);
+            write(dump_fd, buf, nbytes);
+        }
 
         header.cmd = 0;
     }


### PR DESCRIPTION
It's interesting (and maybe useful too) to see what's going on in those Frame messages. Something similar could be added for the other message types too. 

Sometimes there isn't a URI and I'm not sure why, maybe it's linked to the packets with the bad lengths.

I also added something to specifically highlight which were audio key messages, but only because I happen to look into what they were. 